### PR TITLE
🐛 Fix Okuna Web not working in non-Chromium browsers

### DIFF
--- a/lib/matchers/CommunityNameMatcher.ts
+++ b/lib/matchers/CommunityNameMatcher.ts
@@ -1,3 +1,3 @@
-const CommunitynameMatcher = RegExp('((?:(?<=\\s)|^)([/]?)c/([A-Za-z0-9]|[_](?![_])){1,30})(?=\\b|$)');
+const CommunitynameMatcher = RegExp('((?:\\s|^)([/]?)c/([A-Za-z0-9]|[_](?![_])){1,30})(?=\\b|$)');
 
 export default CommunitynameMatcher;


### PR DESCRIPTION
This PR fixes the regex compatibility issue causing non-Chromium browsers to not be able to load Okuna.

**Browsers to test before merging**

- [x] Chrome
- [x] Other Chromium-based (tested in Vivaldi)
- [x] Firefox
- [x] Safari
- [x] Edge (non-Chromium)