### PR TITLE
🐛 Fix newlines not being respected in post and comment texts

### DIFF
--- a/assets/styles/global/modifiers/_text.scss
+++ b/assets/styles/global/modifiers/_text.scss
@@ -32,6 +32,10 @@
   }
 }
 
+.has-preserved-whitespace {
+  white-space: pre-wrap;
+}
+
 .is-size-8 {
   font-size: 0.50rem;
 }

--- a/components/smart-text/OkSmartText.vue
+++ b/components/smart-text/OkSmartText.vue
@@ -1,14 +1,12 @@
 <template>
-    <text-highlight
+    <text-highlight class="has-preserved-whitespace"
             :queries="textHighlightQueries"
             :highlightComponent="customTextHighlightItem"
             @onHashtagPressed="onHashtagPressed"
             @onUsernamePressed="onUsernamePressed"
             @onCommunityNamePressed="onCommunityNamePressed"
             @onUrlPressed="onUrlPressed"
-    >
-        {{text}}
-    </text-highlight>
+    >{{text}}</text-highlight>
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
~~This PR changes the text of posts and comments into arrays with each element being a line of text. `OkSmartText` will then place these lines in separate `p` elements, rather than putting all text into a single element (which gets rid of all whitespace formatting).~~

~~Currently, the default styling is used for the `p` elements but we might want to tweak e.g. the line height to be more in line with the mobile app in order to better preserve the way posts look (but I don't know how to go about and do that in a good way yet).~~

~~Also, even with this PR we are still not properly preserving other types of whitespace (e.g. multiple space characters in a row).~~

Updated to use a purely CSS-based solution which covers both newlines and other whitespace, and is much shorter and tidier. :)

(Fixes #11)

------
Since this is my first ever piece of code relating to Vue there might be a better way of solving this issue which I don't know about. Please let me know if that is the case. 🙂