### PR TITLE
🐛 Fix incorrect posts loaded on scroll in Trending and Explore

### DIFF
--- a/models/posts/top-post/ITopPost.ts
+++ b/models/posts/top-post/ITopPost.ts
@@ -3,6 +3,7 @@ import { IPost } from '~/models/posts/post/IPost';
 
 
 export interface ITopPost extends IDataModel<ITopPost> {
+    id: number;
     post: IPost;
     created: Date;
 }

--- a/models/posts/top-post/TopPost.ts
+++ b/models/posts/top-post/TopPost.ts
@@ -12,6 +12,7 @@ import { ITopPost } from '~/models/posts/top-post/ITopPost';
 
 
 export class TopPost extends DataModel<TopPost> implements ITopPost {
+    id: number;
     post: IPost;
     created: Date;
 

--- a/models/posts/trending-post/ITrendingPost.ts
+++ b/models/posts/trending-post/ITrendingPost.ts
@@ -3,6 +3,7 @@ import { IPost } from '~/models/posts/post/IPost';
 
 
 export interface ITrendingPost extends IDataModel<ITrendingPost> {
+    id: number;
     post: IPost;
     created: Date;
 }

--- a/models/posts/trending-post/TrendingPost.ts
+++ b/models/posts/trending-post/TrendingPost.ts
@@ -12,6 +12,7 @@ import { ITrendingPost } from '~/models/posts/trending-post/ITrendingPost';
 
 
 export class TrendingPost extends DataModel<TrendingPost> implements ITrendingPost {
+    id: number;
     post: IPost;
     created: Date;
 

--- a/services/user/IUserService.ts
+++ b/services/user/IUserService.ts
@@ -51,6 +51,8 @@ import {
     UnfollowUserParams
 } from '~/services/user/UserServiceTypes';
 import { IPost } from '~/models/posts/post/IPost';
+import { ITopPost } from "~/models/posts/top-post/ITopPost";
+import { ITrendingPost } from "~/models/posts/trending-post/ITrendingPost";
 import { IPostMedia } from '~/models/posts/post-media/IPostMedia';
 import { IPostComment } from '~/models/posts/post-comment/IPostComment';
 import { IPostReaction } from '~/models/posts/post-reaction/IPostReaction';
@@ -146,9 +148,9 @@ export interface IUserService {
 
     // POSTS START
 
-    getTopPosts(params?: GetTopPostsParams): Promise<IPost[]>;
+    getTopPosts(params?: GetTopPostsParams): Promise<ITopPost[]>;
 
-    getTrendingPosts(params?: GetTrendingPostsParams): Promise<IPost[]>;
+    getTrendingPosts(params?: GetTrendingPostsParams): Promise<ITrendingPost[]>;
 
     getTimelinePosts(params?: GetTimelinePostsParams): Promise<IPost[]>;
 

--- a/services/user/UserService.ts
+++ b/services/user/UserService.ts
@@ -80,6 +80,8 @@ import { UserData } from '~/types/models-data/auth/UserData';
 import { IPostComment } from '~/models/posts/post-comment/IPostComment';
 import { IPostMedia } from '~/models/posts/post-media/IPostMedia';
 import { IPost } from '~/models/posts/post/IPost';
+import { ITopPost } from "~/models/posts/top-post/ITopPost";
+import { ITrendingPost } from "~/models/posts/trending-post/ITrendingPost";
 import { IPostCommentReaction } from '~/models/posts/post-comment-reaction/IPostCommentReaction';
 import { IReactionsEmojiCount } from '~/models/posts/reactions-emoji-count/IReactionsEmojiCount';
 import { IPostReaction } from '~/models/posts/post-reaction/IPostReaction';
@@ -541,24 +543,24 @@ export class UserService implements IUserService {
         return postFactory.makeMultiple(response.data);
     }
 
-    async getTopPosts(params: GetTopPostsParams = {}): Promise<IPost[]> {
+    async getTopPosts(params: GetTopPostsParams = {}): Promise<ITopPost[]> {
         const response: AxiosResponse<TopPostData[]> = await this.postsApiService.getTopPosts({
             minId: params.minId,
             maxId: params.maxId,
             count: params.count,
         });
 
-        return topPostFactory.makeMultiple(response.data).map((topPost) => topPost.post);
+        return topPostFactory.makeMultiple(response.data);
     }
 
-    async getTrendingPosts(params: GetTrendingPostsParams = {}): Promise<IPost[]> {
+    async getTrendingPosts(params: GetTrendingPostsParams = {}): Promise<ITrendingPost[]> {
         const response: AxiosResponse<TrendingPostData[]> = await this.postsApiService.getTrendingPosts({
             minId: params.minId,
             maxId: params.maxId,
             count: params.count,
         });
 
-        return trendingPostFactory.makeMultiple(response.data).map((trendingPost) => trendingPost.post);
+        return trendingPostFactory.makeMultiple(response.data);
     }
 
     async reactToPost(params: ReactToPostParams): Promise<IPostReaction> {


### PR DESCRIPTION
The Trending and Explore feeds used the posts' IDs as references when loading new posts on scroll. These posts have secondary IDs to order them in the trending/explore feeds. We now use those secondary IDs instead for the API requests.

Fixed problems:
- [x] Explore only loading in the same 10 posts over and over again as you scroll down.
- [x] Trending showing posts from 6 months ago after the first 10 posts, and then starts to loop the same 10 posts over and over again.

(This PR uses the same solution as we do in the Okuna App.)