### PR TITLE
♿️ Highlights the bio link of the users

### DIFF
--- a/pages/home/pages/user/components/shared/OkUserProfileUrl.vue
+++ b/pages/home/pages/user/components/shared/OkUserProfileUrl.vue
@@ -1,7 +1,9 @@
 <template>
     <div>
         <ok-link-icon class="ok-svg-icon-primary-invert-80"></ok-link-icon>
-        <span class="ok-has-text-primary-invert-80 is-size-7-touch">{{user.profile.url}}</span>
+        <span class="ok-has-text-primary-invert-80 is-size-7-touch">
+            <ok-smart-text :text="user.profile.url"></ok-smart-text>
+        </span>      
     </div>
 </template>
 


### PR DESCRIPTION
This PR addresses #43 

I would still leave the `ok-smart-text` component in the `span`-element so that the link is displayed in the same size as location and age on the smartphone.