### PR TITLE
🐛 fix overflowing of videos in post theater modal

### DIFF
--- a/components/post-theatre/post-theatre-media/components/OkPostTheatreMediaVideo.vue
+++ b/components/post-theatre/post-theatre-media/components/OkPostTheatreMediaVideo.vue
@@ -59,7 +59,6 @@
                 language: "en",
                 loop: true,
                 autoplay: true,
-                fluid: true,
                 sources: [{
                     type: "video/mp4",
                     src: postVideoMp4Format.file

--- a/components/post/components/post-media/OkPostMedia.vue
+++ b/components/post/components/post-media/OkPostMedia.vue
@@ -108,7 +108,13 @@
             return this.postMedia[0];
         }
 
-        onWantsToExpandPost() {
+        onWantsToExpandPost(e: Event) {
+            const element = e.target as HTMLElement;
+            if (element?.closest('.vjs-control-bar')) {
+                // User clicked on a videojs control item, don't show modal in this scenario.
+                return;
+            }
+
             this.modalService.openPostModal({
                 post: this.post
             });


### PR DESCRIPTION
Videos have previously not displayed properly in the post theater modal. They were stretched to the point that the video was overflowing from the window. This PR fixes that.

Additionally, this PR also makes it so that clicking on the video.js controls will not open the post theater modal but instead perform the action of the video.js control button (originally reported by @Komposten).

Possibly related issue: #28 (I couldn't replicate this for images, only videos)

![image](https://user-images.githubusercontent.com/20266711/119407098-6ce23580-bcec-11eb-8391-1c05903b6483.png)
