### PR TITLE
🐛 use localStorage where localForage cant be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "howler": "^2.2.0",
     "inversify": "^5.0.1",
     "loaders.css": "^0.1.2",
-    "localforage": "^1.7.3",
+    "localforage": "^1.9.0",
     "localforage-nuxt": "^1.0.10",
     "lodash.debounce": "^4.0.8",
     "lru_map": "^0.3.3",

--- a/pages/home/OkHomePage.vue
+++ b/pages/home/OkHomePage.vue
@@ -72,7 +72,7 @@
             this.logger = this.loggingService!.getLogger({
                 name: "OkHomePage"
             });
-            this.storage = this.storageService.getLocalForageStorage("okHomePage");
+            this.storage = this.storageService.getStorage("okHomePage");
             this.attemptToBootstrapLoggedInUser();
         }
 
@@ -110,6 +110,3 @@
         }
     }
 </script>
-
-
-

--- a/plugins/di-vue.ts
+++ b/plugins/di-vue.ts
@@ -6,12 +6,23 @@ import { ILocalizationService } from '~/services/localization/ILocalizationServi
 import { IBootstrapService } from '~/services/bootstrap/IBootstrapService';
 import { INavigationService } from '~/services/navigation/INavigationService';
 
-export default function (ctx: any, inject: any) {
+export default async function (ctx: any, inject: any) {
     if (!ctx.$localForage) {
         console.error('Please make sure localForage module is added');
     } else {
         const storageService = okunaContainer.get<IStorageService>(TYPES.StorageService);
-        storageService.setLocalForage(ctx.$localForage);
+
+        try {
+            storageService.setStorage(ctx.$localForage);
+
+            // cheap way to test if IndexedDB can be used
+            await storageService.getStorage('initialtest').set('localforagetest', true);
+            await storageService.getStorage('initialtest').clear();
+        } catch (_) {
+            // localForage/IDB can't be used, we are probably in private mode
+            // fallback to localStorage
+            storageService.setStorage(window.localStorage);
+        }
     }
 
     if (!ctx.$axios) {

--- a/services/notifications/NotificationsService.ts
+++ b/services/notifications/NotificationsService.ts
@@ -37,7 +37,7 @@ export class NotificationsService implements INotificationsService {
         @inject(TYPES.LoggingService)  loggingService?: ILoggingService,
         @inject(TYPES.UserService) private userService?: IUserService,
     ) {
-        this.storage = storageService!.getLocalForageStorage('notificationsService');
+        this.storage = storageService!.getStorage('notificationsService');
         this.logger = loggingService.getLogger({
             name: 'NotificationsService'
         });

--- a/services/storage/IStorageService.ts
+++ b/services/storage/IStorageService.ts
@@ -1,8 +1,9 @@
 import { IOkStorage } from '~/services/storage/lib/okuna-storage/IOkStorage';
 
-export interface IStorageService {
-    // @ts-ignore
-    setLocalForage(localForage: LocalForage): void;
+// @ts-ignore
+export type StorageContainer = LocalForage | Storage;
 
-    getLocalForageStorage<T>(namespace: string): IOkStorage<T>;
+export interface IStorageService {
+    setStorage(storage: StorageContainer): void;
+    getStorage<T>(namespace: string): IOkStorage<T>;
 }

--- a/services/storage/StorageService.ts
+++ b/services/storage/StorageService.ts
@@ -1,31 +1,30 @@
-import { IStorageService } from '~/services/storage/IStorageService';
+import { IStorageService, StorageContainer } from '~/services/storage/IStorageService';
 import { IOkStorage } from '~/services/storage/lib/okuna-storage/IOkStorage';
 import okunaStorageFactory from '~/services/storage/lib/okuna-storage/factory';
 import { injectable } from '~/node_modules/inversify';
 
 @injectable()
 export class StorageService implements IStorageService {
-    // @ts-ignore
-    private localForage: LocalForage;
+    private storage: StorageContainer;
 
     constructor() {
     }
 
-    // @ts-ignore
-    setLocalForage(localForage: LocalForage) {
-        this.localForage = localForage;
+    setStorage(storage: StorageContainer) {
+        this.storage = storage
     }
 
-    getLocalForageStorage<T>(namespace: string): IOkStorage<T> {
-        if (!this.localForage) throw new Error('this.localForage is undefined');
+    getStorage<T>(namespace: string): IOkStorage<T> {
+        if (!this.storage) throw new Error('this.storage is undefined');
 
-        return okunaStorageFactory.makeLocalForage<T>(
-            namespace,
-            this.localForage
-        );
+        return this.storage instanceof Storage
+            ? okunaStorageFactory.makeLocalStorage<T>(
+                namespace,
+                this.storage
+            )
+            : okunaStorageFactory.makeLocalForage<T>(
+                namespace,
+                this.storage
+            );
     }
 }
-
-
-
-

--- a/services/storage/lib/okuna-storage/factory.ts
+++ b/services/storage/lib/okuna-storage/factory.ts
@@ -1,11 +1,15 @@
 import { OkStorage } from '~/services/storage/lib/okuna-storage/OkStorage';
 import { IOkStorage } from '~/services/storage/lib/okuna-storage/IOkStorage';
 import { LocalForageStore } from '~/services/storage/lib/stores/LocalForage';
-
+import { LocalStorageStore } from '../stores/LocalStorage';
 
 const okunaStorageFactory = {
     makeLocalForage<T>(namespace: string, localForage: any): IOkStorage<T> {
         return new OkStorage(namespace, new LocalForageStore(localForage));
+    },
+
+    makeLocalStorage<T>(namespace: string, localStorage: Storage): IOkStorage<T> {
+        return new OkStorage(namespace, new LocalStorageStore(localStorage));
     }
 };
 

--- a/services/storage/lib/stores/LocalStorage.ts
+++ b/services/storage/lib/stores/LocalStorage.ts
@@ -1,0 +1,34 @@
+import { IStore } from '~/services/storage/lib/stores/IStore';
+
+export class LocalStorageStore<T> implements IStore<T> {
+    // @ts-ignore
+    constructor(private localStorage: Storage) {
+    }
+
+    clear(): Promise<void> {
+        return Promise.resolve(this.localStorage.clear());
+    }
+
+    get(key: string): Promise<T> {
+        return Promise.resolve(JSON.parse(this.localStorage.getItem(key)));
+    }
+
+    set(key: string, value: T): Promise<void> {
+        return Promise.resolve(this.localStorage.setItem(key, JSON.stringify(value)));
+    }
+
+    has(key: string): Promise<boolean> {
+        const item = this.localStorage.getItem(key);
+        return Promise.resolve(typeof item !== 'undefined' && item !== null);
+    }
+
+    remove(key: string): Promise<T> {
+        const item = this.get(key);
+        this.localStorage.removeItem(key);
+        return Promise.resolve(item);
+    }
+
+    keys(): Promise<string[]> {
+        return Promise.resolve(Object.keys(this.localStorage));
+    }
+}

--- a/services/theme/ThemeService.ts
+++ b/services/theme/ThemeService.ts
@@ -217,7 +217,7 @@ export class ThemeService implements IThemeService {
 
     constructor(@inject(TYPES.StorageService)  storageService?: IStorageService,
                 @inject(TYPES.LoggingService)  loggingService?: ILoggingService,) {
-        this.activeThemeStorage = storageService!.getLocalForageStorage('activeThemeStorage');
+        this.activeThemeStorage = storageService!.getStorage('activeThemeStorage');
         this.logger = loggingService!.getLogger({
             name: ' ThemeService'
         });

--- a/services/user-preferences/UserPreferencesService.ts
+++ b/services/user-preferences/UserPreferencesService.ts
@@ -42,7 +42,7 @@ export class UserPreferencesService implements IUserPreferencesService {
         @inject(TYPES.StorageService)  storageService?: IStorageService,
         @inject(TYPES.LocalizationService) private localizationService?: ILocalizationService,
     ) {
-        this.storage = storageService!.getLocalForageStorage('userPreferencesService');
+        this.storage = storageService!.getStorage('userPreferencesService');
         // TODO Make a library out of this entire behavior of persisting Subjects
         this.bootstrapHashtagDisplaySetting();
         this.bootstrapPostCommentsSortSetting();

--- a/services/user/UserService.ts
+++ b/services/user/UserService.ts
@@ -192,7 +192,7 @@ export class UserService implements IUserService {
                 @inject(TYPES.StorageService)  storageService?: IStorageService,
                 @inject(TYPES.LoggingService)  loggingService?: ILoggingService
     ) {
-        this.tokenStorage = storageService!.getLocalForageStorage('userTokenStorage');
+        this.tokenStorage = storageService!.getStorage('userTokenStorage');
         this.logger = loggingService!.getLogger({
             name: 'UserService'
         });


### PR DESCRIPTION
fixes #98

Although newer versions of Firefox don't seem to have any issues using IndexedDB in private mode, it is still probably a good practice to ensure we can use it as a storage. This PR:

- introduces a new logic for setting and getting storage strategies (with namespace support)
- adds a local storage driver
- upgrades localForage to the latest version
- makes sure localForage can be used in `di-vue`, otherwise it will set the storage driver to localStorage
