### PR TITLE
♻️ global CSS classes for modals

### DIFF
--- a/assets/styles/global/_components.scss
+++ b/assets/styles/global/_components.scss
@@ -3,8 +3,38 @@
   min-height: 100vh;
   flex-direction: column;
 
-
   &-content {
     flex: 1;
   }
+}
+
+$ok-generic-modal-size: 460px;
+$ok-wide-modal-size: 540px;
+
+.ok-generic-modal {
+  width: $ok-generic-modal-size;
+
+  @media only screen and ( max-width: $ok-generic-modal-size ) {
+    width: 95vw;
+  }
+}
+
+.ok-wide-modal {
+  width: $ok-wide-modal-size;
+
+  @media only screen and ( max-width: $ok-wide-modal-size ) {
+    width: auto;
+  }
+}
+
+.ok-actions-modal {
+  min-width: 350px;
+  width: 100%;
+}
+
+.ok-legal-modal {
+  overflow-x: auto;
+  max-height: 700px;
+  max-width: 900px;
+  width: 100%;
 }

--- a/pages/home/components/modals/components/OkCommunityGuidelinesModal.vue
+++ b/pages/home/components/modals/components/OkCommunityGuidelinesModal.vue
@@ -2,7 +2,7 @@
     <div class="is-flex justify-center align-items-center has-height-100-percent has-padding-20">
         <div class="ok-has-background-primary is-semi-rounded is-relative has-height-100-percent">
             <div
-                    class="box ok-has-background-primary-highlight is-paddingless ok-community-guidelines-modal has-height-100-percent-mobile"
+                    class="box ok-has-background-primary-highlight is-paddingless ok-legal-modal has-height-100-percent-mobile"
                     ref="modalBoxContainer">
                 <template v-if="!communityGuidelinesMd">
                     <ok-loading-indicator></ok-loading-indicator>
@@ -12,16 +12,6 @@
         </div>
     </div>
 </template>
-
-<style lang="scss">
-    .ok-community-guidelines-modal {
-        overflow-x: auto;
-        max-height: 700px;
-        max-width: 900px;
-        width: 100%;
-    }
-</style>
-
 
 <script lang="ts">
     import { Component, Prop, Vue } from "nuxt-property-decorator"

--- a/pages/home/components/modals/components/OkCreateCommunityModal.vue
+++ b/pages/home/components/modals/components/OkCreateCommunityModal.vue
@@ -1,23 +1,13 @@
 <template>
     <div class="is-flex justify-center align-items-center">
         <ok-create-community-form
-            class="ok-create-community-modal"
+            class="ok-wide-modal"
             :communityStub="params && params.communityStub"
             :images="params && params.images"
             @onComplete="onComplete"
         />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-create-community-modal {
-        width: 540px;
-
-        @media only screen and ( max-width: 540px ) {
-            width: auto;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/OkPostActionsModal.vue
+++ b/pages/home/components/modals/components/OkPostActionsModal.vue
@@ -1,19 +1,12 @@
 <template>
     <div class="is-flex justify-center align-items-center">
-        <ok-post-more-actions :post="params.post" class="ok-post-actions-modal"
+        <ok-post-more-actions :post="params.post" class="ok-actions-modal"
                          @onPostDeleted="onPostDeleted"
                          @onPostCommentsEnabledChange="onPostCommentsEnabledChange"
                          @onPostClosedChange="onPostClosedChange"
                          :on-post-reported="params.onPostReported"></ok-post-more-actions>
     </div>
 </template>
-
-<style lang="scss">
-    .ok-post-actions-modal {
-        max-width: 350px;
-        width: 100%;
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from "nuxt-property-decorator"

--- a/pages/home/components/modals/components/OkPostCommentActionsModal.vue
+++ b/pages/home/components/modals/components/OkPostCommentActionsModal.vue
@@ -1,18 +1,11 @@
 <template>
     <div class="is-flex justify-center align-items-center">
         <ok-post-comment-more-actions :post-comment="params.postComment" :post="params.post"
-                                      class="ok-post-comment-actions-modal"
+                                      class="ok-actions-modal"
                                       @onPostCommentDeleted="onPostCommentDeleted"
                                       :on-post-comment-reported="params.onPostCommentReported"></ok-post-comment-more-actions>
     </div>
 </template>
-
-<style lang="scss">
-    .ok-post-comment-actions-modal {
-        max-width: 350px;
-        width: 100%;
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from "nuxt-property-decorator"

--- a/pages/home/components/modals/components/OkPrivacyPolicyModal.vue
+++ b/pages/home/components/modals/components/OkPrivacyPolicyModal.vue
@@ -2,7 +2,7 @@
     <div class="is-flex justify-center align-items-center has-height-100-percent has-padding-20">
         <div class="ok-has-background-primary is-semi-rounded is-relative has-height-100-percent">
             <div
-                    class="box ok-has-background-primary-highlight is-paddingless ok-privacy-policy-modal has-height-100-percent-mobile"
+                    class="box ok-has-background-primary-highlight is-paddingless ok-legal-modal has-height-100-percent-mobile"
                     ref="modalBoxContainer">
                 <template v-if="!privacyPolicyMd">
                     <ok-loading-indicator></ok-loading-indicator>
@@ -12,16 +12,6 @@
         </div>
     </div>
 </template>
-
-<style lang="scss">
-    .ok-privacy-policy-modal {
-        overflow-x: auto;
-        max-height: 700px;
-        max-width: 900px;
-        width: 100%;
-    }
-</style>
-
 
 <script lang="ts">
     import { Component, Prop, Vue } from "nuxt-property-decorator"

--- a/pages/home/components/modals/components/OkTermsOfUseModal.vue
+++ b/pages/home/components/modals/components/OkTermsOfUseModal.vue
@@ -2,7 +2,7 @@
     <div class="is-flex justify-center align-items-center has-height-100-percent has-padding-20">
         <div class="ok-has-background-primary is-semi-rounded is-relative has-height-100-percent">
             <div
-                    class="box ok-has-background-primary-highlight is-paddingless ok-terms-of-use-modal has-height-100-percent-mobile"
+                    class="box ok-has-background-primary-highlight is-paddingless ok-legal-modal has-height-100-percent-mobile"
                     ref="modalBoxContainer">
                 <template v-if="!termsOfUseMd">
                     <ok-loading-indicator></ok-loading-indicator>
@@ -12,16 +12,6 @@
         </div>
     </div>
 </template>
-
-<style lang="scss">
-    .ok-terms-of-use-modal {
-        overflow-x: auto;
-        max-height: 700px;
-        max-width: 900px;
-        width: 100%;
-    }
-</style>
-
 
 <script lang="ts">
     import { Component, Prop, Vue } from "nuxt-property-decorator"

--- a/pages/home/components/modals/components/OkUserActionsModal.vue
+++ b/pages/home/components/modals/components/OkUserActionsModal.vue
@@ -1,19 +1,12 @@
 <template>
     <div class="is-flex justify-center align-items-center">
-        <ok-user-more-actions :user="params.user" class="ok-user-actions-modal"
+        <ok-user-more-actions :user="params.user" class="ok-actions-modal"
                               @onDisconnectedFromUser="onDisconnectedFromUser"
                               @onConnectionConfirmed="onConnectionConfirmed"
                               @onUserIsBlockedChange="onUserIsBlockedChange"
                               :on-user-reported="params.onUserReported"></ok-user-more-actions>
     </div>
 </template>
-
-<style lang="scss">
-    .ok-user-actions-modal {
-        max-width: 350px;
-        width: 100%;
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from "nuxt-property-decorator"

--- a/pages/home/components/modals/components/OkUserFollowersModal.vue
+++ b/pages/home/components/modals/components/OkUserFollowersModal.vue
@@ -1,18 +1,8 @@
 <template>
     <div class="is-flex justify-center align-items-center">
-        <ok-user-followers class="ok-user-followers-modal" />
+        <ok-user-followers class="ok-generic-modal" />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-user-followers-modal {
-        width: 460px;
-
-        @media only screen and ( max-width: 460px ) {
-            width: 95vw;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/OkUserFollowingsModal.vue
+++ b/pages/home/components/modals/components/OkUserFollowingsModal.vue
@@ -1,18 +1,8 @@
 <template>
     <div class="is-flex justify-center align-items-center">
-        <ok-user-followings class="ok-user-followings-modal" />
+        <ok-user-followings class="ok-generic-modal" />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-user-followings-modal {
-        width: 460px;
-
-        @media only screen and ( max-width: 460px ) {
-            width: 95vw;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/circles/OkCircleDetailsModal.vue
+++ b/pages/home/components/modals/components/circles/OkCircleDetailsModal.vue
@@ -1,22 +1,12 @@
 <template>
     <div class="is-flex justify-center align-items-center">
         <ok-circle-details
-            class="ok-circle-details-modal"
+            class="ok-generic-modal"
             :circle="params.circle"
             :isConnectionsCircle="params.isConnectionsCircle"
         ></ok-circle-details>
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-circle-details-modal {
-        width: 460px;
-
-        @media only screen and ( max-width: 460px ) {
-            width: 95vw;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/circles/OkCirclesModal.vue
+++ b/pages/home/components/modals/components/circles/OkCirclesModal.vue
@@ -1,18 +1,8 @@
 <template>
     <div class="is-flex justify-center align-items-center">
-        <ok-circles class="ok-circles-modal"></ok-circles>
+        <ok-circles class="ok-generic-modal"></ok-circles>
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-circles-modal {
-        width: 460px;
-
-        @media only screen and ( max-width: 460px ) {
-            width: 95vw;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/circles/OkCreateCircleModal.vue
+++ b/pages/home/components/modals/components/circles/OkCreateCircleModal.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="is-flex justify-center align-items-center">
         <ok-circle-details-form
-            class="ok-create-circle-modal"
+            class="ok-generic-modal"
             :modalTitle="$t('manage_circles.create_circle.title')"
             :requestInProgress="requestInProgress"
             @submit="handleSubmit"
@@ -9,16 +9,6 @@
         />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-create-circle-modal {
-        width: 460px;
-
-        @media only screen and ( max-width: 460px ) {
-            width: 95vw;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/circles/OkEditCircleModal.vue
+++ b/pages/home/components/modals/components/circles/OkEditCircleModal.vue
@@ -1,21 +1,11 @@
 <template>
     <div class="is-flex justify-center align-items-center">
         <ok-edit-circle
-            class="ok-edit-circle-modal"
+            class="ok-generic-modal"
             :circle="params.circle"
         ></ok-edit-circle>
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-edit-circle-modal {
-        width: 460px;
-
-        @media only screen and ( max-width: 460px ) {
-            width: 95vw;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/community-settings/OkCommunityAddAdministratorModal.vue
+++ b/pages/home/components/modals/components/community-settings/OkCommunityAddAdministratorModal.vue
@@ -1,18 +1,8 @@
 <template>
     <div class="is-flex justify-center align-items-center">
-        <ok-community-add-administrator class="ok-community-add-administrator-modal" :community="params.community" />
+        <ok-community-add-administrator class="ok-generic-modal" :community="params.community" />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-community-add-administrator-modal {
-        width: 460px;
-
-        @media only screen and ( max-width: 460px ) {
-            width: 95vw;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/community-settings/OkCommunityAddBannedUserModal.vue
+++ b/pages/home/components/modals/components/community-settings/OkCommunityAddBannedUserModal.vue
@@ -1,18 +1,8 @@
 <template>
     <div class="is-flex justify-center align-items-center">
-        <ok-community-add-banned-user class="ok-community-add-banned-user-modal" :community="params.community" />
+        <ok-community-add-banned-user class="ok-generic-modal" :community="params.community" />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-community-add-banned-user-modal {
-        width: 460px;
-
-        @media only screen and ( max-width: 460px ) {
-            width: 95vw;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/community-settings/OkCommunityAddModeratorModal.vue
+++ b/pages/home/components/modals/components/community-settings/OkCommunityAddModeratorModal.vue
@@ -1,18 +1,8 @@
 <template>
     <div class="is-flex justify-center align-items-center">
-        <ok-community-add-moderator class="ok-community-add-moderator-modal" :community="params.community" />
+        <ok-community-add-moderator class="ok-generic-modal" :community="params.community" />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-community-add-moderator-modal {
-        width: 460px;
-
-        @media only screen and ( max-width: 460px ) {
-            width: 95vw;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/community-settings/OkCommunityAdministratorsSettingsModal.vue
+++ b/pages/home/components/modals/components/community-settings/OkCommunityAdministratorsSettingsModal.vue
@@ -1,18 +1,8 @@
 <template>
     <div class="is-flex justify-center align-items-center">
-        <ok-community-administrators-settings class="ok-community-administrators-settings-modal" :community="params.community" />
+        <ok-community-administrators-settings class="ok-generic-modal" :community="params.community" />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-community-administrators-settings-modal {
-        width: 460px;
-
-        @media only screen and ( max-width: 460px ) {
-            width: 95vw;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/community-settings/OkCommunityBannedUsersSettingsModal.vue
+++ b/pages/home/components/modals/components/community-settings/OkCommunityBannedUsersSettingsModal.vue
@@ -1,18 +1,8 @@
 <template>
     <div class="is-flex justify-center align-items-center">
-        <ok-community-bans-settings class="ok-community-bans-settings-modal" :community="params.community" />
+        <ok-community-bans-settings class="ok-generic-modal" :community="params.community" />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-community-bans-settings-modal {
-        width: 460px;
-
-        @media only screen and ( max-width: 460px ) {
-            width: 95vw;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/community-settings/OkCommunityDetailsSettingsModal.vue
+++ b/pages/home/components/modals/components/community-settings/OkCommunityDetailsSettingsModal.vue
@@ -1,23 +1,13 @@
 <template>
     <div class="is-flex justify-center align-items-center">
         <ok-community-details-settings
-            class="ok-community-details-settings-modal"
+            class="ok-wide-modal"
             :images="params && params.images"
             :community="params && params.community"
             @onSaveComplete="onSaveComplete"
         />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-community-details-settings-modal {
-        width: 540px;
-
-        @media only screen and ( max-width: 540px ) {
-            width: auto;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/community-settings/OkCommunityModeratorsSettingsModal.vue
+++ b/pages/home/components/modals/components/community-settings/OkCommunityModeratorsSettingsModal.vue
@@ -1,18 +1,8 @@
 <template>
     <div class="is-flex justify-center align-items-center">
-        <ok-community-moderators-settings class="ok-community-moderators-settings-modal" :community="params.community" />
+        <ok-community-moderators-settings class="ok-generic-modal" :community="params.community" />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-community-moderators-settings-modal {
-        width: 460px;
-
-        @media only screen and ( max-width: 460px ) {
-            width: 95vw;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/user-settings/OkImageCropperModal.vue
+++ b/pages/home/components/modals/components/user-settings/OkImageCropperModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="is-flex justify-center align-items-center ok-image-cropper-modal">
+    <div class="is-flex justify-center align-items-center ok-wide-modal">
         <ok-image-cropper
             v-if="params"
             class="ok-image-cropper"
@@ -13,16 +13,6 @@
         />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-image-cropper-modal {
-        width: 540px;
-
-        @media only screen and ( max-width: 540px ) {
-            width: auto;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';

--- a/pages/home/components/modals/components/user-settings/OkUserProfileSettingsModal.vue
+++ b/pages/home/components/modals/components/user-settings/OkUserProfileSettingsModal.vue
@@ -1,22 +1,12 @@
 <template>
     <div class="is-flex justify-center align-items-center">
         <ok-user-profile-settings
-            class="ok-user-profile-settings-modal"
+            class="ok-wide-modal"
             :images="params && params.images"
             @onSaveComplete="onSaveComplete"
         />
     </div>
 </template>
-
-<style lang="scss" scoped>
-    .ok-user-profile-settings-modal {
-        width: 540px;
-
-        @media only screen and ( max-width: 540px ) {
-            width: auto;
-        }
-    }
-</style>
 
 <script lang="ts">
     import { Component, Prop, Vue } from 'nuxt-property-decorator';


### PR DESCRIPTION
Modal classes were redefined in a lot of modal components. This PR creates four global classes that we can reuse for modals:

- `ok-generic-modal` (for generic modals like the followers list modal).
**Affected modals:** user followers, user followings, circles list, create circle, circle details, edit circle, add community administrator, add community moderator, add community banned user, community administrators settings, community moderator settings, community banned users settings.

- `ok-wide-modal` (for modals that require more space).
**Affected modals:** create community, community details settings, image cropper, profile settings.

- `ok-actions-modal` (for modals that only contain action tiles).
**Affected modals:** post more actions, post comment actions, user more actions.

- `ok-legal-modal` (for modals that render a legal document).
**Affected modals:** community guidelines, privacy policy, terms of use.